### PR TITLE
Need to create and mount /var/log dir for kubelet container to be able to create symlinks for logs.  And execute custom kublet-wrapper script if available before executing default one.

### DIFF
--- a/files/kubelet-wrapper.sh
+++ b/files/kubelet-wrapper.sh
@@ -18,17 +18,20 @@ mkdir --parents /etc/kubernetes
 mkdir --parents /var/lib/docker
 mkdir --parents /var/lib/kubelet
 mkdir --parents /run/kubelet
+mkdir --parents /var/log/containers
 
 exec /usr/bin/rkt run \
   --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
   --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
   --volume var-lib-docker,kind=host,source=/var/lib/docker \
   --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet \
+  --volume var-log,kind=host,source=/var/log,readOnly=false \
   --volume run,kind=host,source=/run \
   --mount volume=etc-kubernetes,target=/etc/kubernetes \
   --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
   --mount volume=var-lib-docker,target=/var/lib/docker \
   --mount volume=var-lib-kubelet,target=/var/lib/kubelet \
+  --mount volume=var-log,target=/var/log \
   --mount volume=run,target=/run \
   --trust-keys-from-https \
   $RKT_OPTS \

--- a/templates/kubelet-wrapper
+++ b/templates/kubelet-wrapper
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 BUILTIN_WRAPPER=/usr/lib/coreos/kubelet-wrapper
-if [ -e "$BUILTIN_WRAPPER" ]; then
+CUSTOM_WRAPPER={{coreos_kubelet_install_dir}}/kubelet-wrapper.sh
+
+if [ -e "$CUSTOM_WRAPPER" ]; then
+    exec "$CUSTOM_WRAPPER" "$@"
+elif [ -e "$BUILTIN_WRAPPER" ]; then
     exec "$BUILTIN_WRAPPER" "$@"
 fi
-
-exec {{coreos_kubelet_install_dir}}/kubelet-wrapper.sh "$@"


### PR DESCRIPTION
Tested this on my local cluster. Have been running logging service with this change.
@sigma  @puneetkatyal @imkin Please let me know if I need to add more details here. Can I please get this reviewed and pulled?

Thanks!
Vishal