### PR TITLE
Remove deprecated options: --api-servers, --register-schedulable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,8 +6,6 @@ kubelet_version: "v1.7.0_coreos.0"
 kubelet_aci: "quay.io/coreos/hyperkube"
 kubernetes_service_addresses: "172.21.0.0/16"
 dns_server: "{{ kubernetes_service_addresses|ipaddr('net')|ipaddr(100)|ipaddr('address') }}"
-kube_master_register: false
-kube_apiserver_secure_port: 6443
 
 kubelet_extra_rkt_run_args: ""
 

--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -14,14 +14,8 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
   --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --register-node=true \
 {% if inventory_hostname in groups['kubernetes-masters'] %}
-  --api_servers=http://127.0.0.1:8080 \
-  {% if inventory_hostname in groups['kubernetes-minions'] %}
-  --register-schedulable=true \
-  {% else %}
-  --register-schedulable={{ kube_master_register | ternary('true', 'false') }} \
-  {% endif %}
+  --kubeconfig=/etc/kubernetes/apiserver-kubeconfig.yaml \
 {% else %}
-  --api_servers={{ groups['kubernetes-masters'] | map('extract', hostvars, ['ansible_default_ipv4', 'address']) | list | map('regex_replace', '^(.*)$', 'https://\\1:'~kube_apiserver_secure_port) | list | join(',') }} \
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \


### PR DESCRIPTION
- Use server info from kubeconfig instead of deprecated '--api-servers' option
- Master nodes are made unschedulable by default using taints --
  https://github.com/kubernetes-incubator/kube-aws/issues/286#issuecomment-275587871