### PR TITLE
Kubelet: Add default option: cadvisor_port: 0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ default_kubelet_options:
   image_gc_high_threshold: 90
   image_gc_low_threshold: 80
   minimum_image_ttl_duration: "60m"
+  cadvisor_port: 0
 
 custom_kubelet_options: {}
 

--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -10,7 +10,6 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
   --hostname-override={{ansible_default_ipv4.address}} \
   --cluster_dns={{dns_server}} \
   --cluster_domain=cluster.local \
-  --cadvisor-port=0 \
   --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --register-node=true \
 {% if inventory_hostname in groups['kubernetes-masters'] %}


### PR DESCRIPTION
Enable cadvisor port: 4194. 
Tested the change in my dev cluster.

core@coreos-minion-04 ~ $ curl http://localhost:4194/metrics
 HELP cadvisor_version_info A metric with a constant '1' value labeled by kernel version, OS version, docker version, cadvisor version & cadvisor revision.
 TYPE cadvisor_version_info gauge
cadvisor_version_info{cadvisorRevision="",cadvisorVersion="",dockerVersion="1.12.6",kernelVersion="4.11.9-coreos",osVersion="Debian GNU/Linux 8 (jessie)"} 1
 HELP container_cpu_cfs_periods_total Number of elapsed enforcement period intervals.
 TYPE container_cpu_cfs_periods_total counter
container_cpu_cfs_periods_total{id="/kubepods/burstable/pod38d50c56-9c5d-11e7-adbf-02000be7e138"} 3.715026e+06
container_cpu_cfs_periods_total{id="/kubepods/burstable/pod90e36055-83d5-11e7-ac23-02000be7e138"} 710686
container_cpu_cfs_periods_total{id="/kubepods/burstable/podd8e7fd18-93b2-11e7-82ad-02000be7e138"} 1.181818e+06
container_cpu_cfs_periods_total{id="/kubepods/pod8fb733dc-83d5-11e7-ac23-02000be7e138"} 94799
...
...
