### PR TITLE
Enable Cloud Provider

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,3 +18,5 @@ default_kubelet_options:
 custom_kubelet_options: {}
 
 kubelet_options: "{{ default_kubelet_options | combine(custom_kubelet_options) }}"
+kube_cloud_provider: "vsphere"
+kube_enable_cloud_provider: False

--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -8,8 +8,8 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
   --allow-privileged=true \
   --pod-manifest-path=/etc/kubernetes/manifests \
   --hostname-override={{ansible_default_ipv4.address}} \
-  --cluster_dns={{dns_server}} \
-  --cluster_domain=cluster.local \
+  --cluster-dns={{dns_server}} \
+  --cluster-domain=cluster.local \
   --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --register-node=true \
 {% if inventory_hostname in groups['kubernetes-masters'] %}
@@ -18,6 +18,9 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
   --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
   --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
+{% endif %}
+{% if kube_enable_cloud_provider %}
+  --cloud-provider={{kube_cloud_provider}}
 {% endif %}
 {% if kubelet_options is defined %}
 {% for key, value in kubelet_options.iteritems() %}


### PR DESCRIPTION
This PR enables k8s cloud provider. The default is set to vSphere.
Note: Before launching this scripts set ```kube_enable_cloud_provider``` to True.
