### PR TITLE
Enable PodPriority feature to set high priority for cluster components

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ dns_server: "{{ kubernetes_service_addresses|ipaddr('net')|ipaddr(100)|ipaddr('a
 kubelet_extra_rkt_run_args: ""
 
 default_kubelet_options:
+  feature_gates: "PodPriority=true"
   image_gc_high_threshold: 90
   image_gc_low_threshold: 80
   minimum_image_ttl_duration: "60m"


### PR DESCRIPTION
Per https://v1-9.docs.kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#enabling-priority-and-preemption