### PR TITLE
Start kubelet.service after docker.service

### DIFF
--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Kubelet Service
 Documentation=https://github.com/kubernetes/kubernetes
+Wants=docker.service
+After=docker.service
 
 [Service]
 EnvironmentFile=-/etc/environment


### PR DESCRIPTION
Kubelet needs docker so it should start only after docker is running. This
dependency also prevents kubelet from starting too early in the boot cycle;
when it does, it bind mounts resolv.conf blocking systemd-resolved from adding
name servers obtained from the gateway to resolv.conf