### PR TITLE
Limit kubelet service to 10 restarts in 10 minutes to prevent infinite reboots that quickly fill up the disk with exited rkt containers

### DIFF
--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -3,6 +3,8 @@ Description=Kubelet Service
 Documentation=https://github.com/kubernetes/kubernetes
 Wants=docker.service
 After=docker.service
+StartLimitIntervalSec=600
+StartLimitBurst=10
 
 [Service]
 EnvironmentFile=-/etc/environment


### PR DESCRIPTION
Limit kubelet service to 10 restarts in 10 minutes to prevent infinite reboots that quickly fill up the disk with exited rkt containers