### PR TITLE
Upgrade Kubernetes to version 1.14.3, Use file based config for kubelet and cleanup deprecated options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,22 +4,23 @@
 # defaults file for ansible-coreos-kubelet
 coreos_kubelet_systemd: /etc/systemd/system
 coreos_kubelet_install_dir: /opt/bin
-kubelet_version: "v1.7.0_coreos.0"
-kubelet_aci: "quay.io/coreos/hyperkube"
+
+kubelet_image_tag: "v1.14.3"
+kubelet_image_url: "docker://gcr.io/google_containers/hyperkube"
+
 kubernetes_service_addresses: "172.21.0.0/16"
 dns_server: "{{ kubernetes_service_addresses|ipaddr('net')|ipaddr(100)|ipaddr('address') }}"
 
 kubelet_extra_rkt_run_args: ""
 
-default_kubelet_options:
-  feature_gates: "PodPriority=true"
-  image_gc_high_threshold: 90
-  image_gc_low_threshold: 80
-  minimum_image_ttl_duration: "60m"
-  cadvisor_port: 0
+## KUBELET options set via kubelet config file
+kubelet_config_file_name: "kubelet-config.yaml"
+kubelet_config_file_src: "{{kubelet_config_file_name}}"
+kubelet_config_dir: "/var/lib/kubelet"
 
+## KUBELET options set via commandline. These override the options in kubelet config file
+default_kubelet_options: {}
 custom_kubelet_options: {}
-
 kubelet_options: "{{ default_kubelet_options | combine(custom_kubelet_options) }}"
 kube_cloud_provider: "vsphere"
 kube_enable_cloud_provider: False

--- a/files/kubelet-wrapper.sh
+++ b/files/kubelet-wrapper.sh
@@ -6,7 +6,7 @@
 # Wrapper for launching kubelet via rkt-fly stage1. 
 #
 # Make sure to set KUBELET_IMAGE_TAG to an image tag published here:
-# https://quay.io/repository/coreos/hyperkube?tab=tags Alternatively,
+# https://gcr.io/google_containers/hyperkube Alternatively,
 # override $KUBELET_IMAGE_URL to a custom location.
 
 set -e
@@ -16,7 +16,7 @@ if [ -z "${KUBELET_IMAGE_TAG}" ]; then
     exit 1
 fi
 
-KUBELET_IMAGE_URL="${KUBELET_IMAGE_URL:-quay.io/coreos/hyperkube}"
+KUBELET_IMAGE_URL="${KUBELET_IMAGE_URL:-gcr.io/google_containers/hyperkube}"
 
 mkdir --parents /etc/kubernetes
 mkdir --parents /var/lib/docker

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,15 @@
   become: yes
   file: path={{coreos_kubelet_install_dir}} state=directory mode=0755
 
+- name: Create kubelet config dir
+  become: yes
+  file: path={{kubelet_config_dir}} state=directory mode=0755
+
+- name: Copy kubelet config
+  become: yes
+  template: src={{kubelet_config_file_src}} dest={{kubelet_config_dir}}/config.yaml mode=0755
+  notify: restart kubelet
+
 - name: Copy kubelet-wrapper.sh
   become: yes
   copy: src=kubelet-wrapper.sh dest={{coreos_kubelet_install_dir}}/kubelet-wrapper.sh mode=0755

--- a/templates/kube.env.j2
+++ b/templates/kube.env.j2
@@ -1,8 +1,3 @@
-# deprecated options (pre 1214)
-KUBELET_VERSION={{kubelet_version}}
-KUBELET_ACI={{kubelet_aci}}
-RKT_OPTS="--volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf --volume etc-ssh,kind=host,source=/etc/ssh --mount volume=etc-ssh,target=/etc/ssh"
-# new options
-KUBELET_IMAGE_TAG={{kubelet_version}}
-KUBELET_IMAGE_URL={{kubelet_aci}}
+KUBELET_IMAGE_TAG={{kubelet_image_tag}}
+KUBELET_IMAGE_URL={{kubelet_image_url}}
 RKT_RUN_ARGS="{{kubelet_extra_rkt_run_args}} --volume etc-resolv,kind=host,source=/etc/resolv.conf --mount volume=etc-resolv,target=/etc/resolv.conf --volume etc-ssh,kind=host,source=/etc/ssh --mount volume=etc-ssh,target=/etc/ssh"

--- a/templates/kubelet-config.yaml
+++ b/templates/kubelet-config.yaml
@@ -1,0 +1,105 @@
+---
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+address: 0.0.0.0
+allowPrivileged: true
+authentication:
+  anonymous:
+    enabled: true
+  webhook:
+    cacheTTL: 2m0s
+    enabled: false
+  x509:
+    clientCAFile: ''
+authorization:
+  mode: AlwaysAllow
+  webhook:
+    cacheAuthorizedTTL: 5m0s
+    cacheUnauthorizedTTL: 30s
+cAdvisorPort: 4194
+cgroupDriver: cgroupfs
+cgroupRoot: ''
+cgroupsPerQOS: true
+clusterDNS:
+- {{dns_server}}
+
+clusterDomain: cluster.local
+configTrialDuration: 10m0s
+contentType: application/vnd.kubernetes.protobuf
+cpuCFSQuota: true
+cpuManagerPolicy: none
+cpuManagerReconcilePeriod: 10s
+enableContentionProfiling: false
+enableControllerAttachDetach: true
+enableDebuggingHandlers: true
+enableServer: true
+enforceNodeAllocatable:
+- pods
+eventBurst: 10
+eventRecordQPS: 5
+## Eviction options
+evictionHard:
+  imagefs.available: 5%
+  memory.available: 500Mi
+  nodefs.available: 5%
+  nodefs.inodesFree: '5'
+evictionMaxPodGracePeriod: 0
+evictionMinimumReclaim:
+  imagefs.available: 10%
+  memory.available: 1Gi
+  nodefs.available: 10%
+  nodefs.inodesFree: '10'
+evictionPressureTransitionPeriod: 5m0s
+evictionSoft:
+evictionSoftGracePeriod:
+failSwapOn: true
+featureGates:
+  PodPriority: true
+fileCheckFrequency: 20s
+hairpinMode: promiscuous-bridge
+healthzBindAddress: 127.0.0.1
+healthzPort: 10248
+hostIPCSources:
+- "*"
+hostNetworkSources:
+- "*"
+hostPIDSources:
+- "*"
+httpCheckFrequency: 20s
+imageGCHighThresholdPercent: 85
+imageGCLowThresholdPercent: 80
+imageMinimumGCAge: 2h0m0s
+iptablesDropBit: 15
+iptablesMasqueradeBit: 14
+kubeAPIBurst: 10
+kubeAPIQPS: 5
+kubeletCgroups: ''
+kubeReserved:
+makeIPTablesUtilChains: true
+maxOpenFiles: 1000000
+maxPods: 50
+nodeStatusReportFrequency: 1m0s
+nodeStatusUpdateFrequency: 10s
+oomScoreAdj: -999
+podCIDR: ''
+staticPodPath: "/etc/kubernetes/manifests"
+
+podsPerCore: 0
+port: 10250
+protectKernelDefaults: false
+readOnlyPort: 10255
+registryBurst: 10
+registryPullQPS: 5
+resolvConf: "/etc/resolv.conf"
+runtimeRequestTimeout: 2m0s
+serializeImagePulls: true
+streamingConnectionIdleTimeout: 4h0m0s
+syncFrequency: 1m0s
+systemCgroups: ''
+systemReserved:
+
+{% if inventory_hostname not in groups['kubernetes-masters'] %}
+tlsCertFile: '/etc/kubernetes/ssl/worker.pem'
+tlsPrivateKeyFile: '/etc/kubernetes/ssl/worker-key.pem'
+{% endif %}
+volumeStatsAggPeriod: 1m0s

--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -4,24 +4,20 @@ Documentation=https://github.com/kubernetes/kubernetes
 Wants=docker.service
 After=docker.service
 StartLimitIntervalSec=600
-StartLimitBurst=10
+StartLimitBurst=20
 
 [Service]
+Restart=always
+RestartSec=10
 EnvironmentFile=-/etc/environment
 ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
-  --allow-privileged=true \
-  --pod-manifest-path=/etc/kubernetes/manifests \
   --hostname-override={{ansible_default_ipv4.address}} \
-  --cluster-dns={{dns_server}} \
-  --cluster-domain=cluster.local \
   --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --register-node=true \
 {% if inventory_hostname in groups['kubernetes-masters'] %}
   --kubeconfig=/etc/kubernetes/apiserver-kubeconfig.yaml \
 {% else %}
   --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
-  --tls-cert-file=/etc/kubernetes/ssl/worker.pem \
-  --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \
 {% endif %}
 {% if kube_enable_cloud_provider %}
   --cloud-provider={{kube_cloud_provider}} \
@@ -31,9 +27,7 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
   --{{key | lower | replace("_", "-") }}={{value}} \
 {% endfor %}
 {% endif %}
-
-Restart=always
-RestartSec=10
+  --config={{kubelet_config_dir}}/config.yaml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Upgrade Kubernetes to 1.14.3
Release notes for Kubernetes 1.14.3 available at https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#v1143
- Move deprecated Kubelet config to kubelet config file. Flags that can be set via the [Kubelet's --config file](https://kubernetes.io/docs/tasks/administer-cluster/kubelet-config-file/) are now deprecated in favor of the file. https://github.com/kubernetes/kubernetes/pull/60148
- The word “manifest” has been expunged from the Kubelet API, change PodManifestPath to StaticPodPath. https://github.com/kubernetes/kubernetes/pull/60314
- Bump up StartLimitBurst to 20, kubelet service restarts many times due to differnt roles invoking restart after each playbook run. current StartLimitBurst prevents from finishing all kubelet related tasks and exits kubelet service before finishing all tasks.
- Templatize and add/update eviction thresholds
- Cleanup deprecated RKT_OPTS
- Also fix the variables names to be more consistent across repos.

Note: KubeletConfiguration has been generated based on current DECC clusters.