### PR TITLE
Fix start rate limiting for kubelet.service

### DIFF
--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -3,8 +3,8 @@ Description=Kubelet Service
 Documentation=https://github.com/kubernetes/kubernetes
 Wants=docker.service
 After=docker.service
-StartLimitIntervalSec=600
-StartLimitBurst=10
+StartLimitIntervalSec=60
+StartLimitBurst=3
 
 [Service]
 EnvironmentFile=-/etc/environment
@@ -33,7 +33,7 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
 {% endif %}
 
 Restart=always
-RestartSec=10
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- With current values, kubelet.service enters failed state for a
  longer period and prevents manual restarts of the service until
  StartLimitIntervalSec seconds have passed unless
  'systemctl reset-failed' is issued.
- Using a smaller interval allows other plays to reliably restart
  the kubelet service once the interval has elapsed and avoid
  'Start request repeated too quickly' errors.