### PR TITLE
If kubernetes_enable_cni=True, start kubelet with --network-plugin=cni option to support CNI Plugins (e.g. Antrea)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ kubelet_image_tag: "v1.14.3"
 kubelet_image_url: "docker://gcr.io/google_containers/hyperkube"
 
 kubernetes_service_addresses: "172.21.0.0/16"
+kubernetes_enable_cni: False
 dns_server: "{{ kubernetes_service_addresses|ipaddr('net')|ipaddr(100)|ipaddr('address') }}"
 
 kubelet_extra_rkt_run_args: ""

--- a/files/kubelet-wrapper.sh
+++ b/files/kubelet-wrapper.sh
@@ -23,15 +23,21 @@ mkdir --parents /var/lib/docker
 mkdir --parents /var/lib/kubelet
 mkdir --parents /run/kubelet
 mkdir --parents /var/log/containers
+mkdir --parents /etc/cni
+mkdir --parents /opt/cni
 
 exec /usr/bin/rkt run \
   --volume etc-kubernetes,kind=host,source=/etc/kubernetes \
+  --volume etc-cni,kind=host,source=/etc/cni \
+  --volume opt-cni,kind=host,source=/opt/cni \
   --volume etc-ssl-certs,kind=host,source=/usr/share/ca-certificates \
   --volume var-lib-docker,kind=host,source=/var/lib/docker \
   --volume var-lib-kubelet,kind=host,source=/var/lib/kubelet,readOnly=false,recursive=true \
   --volume var-log,kind=host,source=/var/log,readOnly=false \
   --volume run,kind=host,source=/run \
   --mount volume=etc-kubernetes,target=/etc/kubernetes \
+  --mount volume=etc-cni,target=/etc/cni \
+  --mount volume=opt-cni,target=/opt/cni \
   --mount volume=etc-ssl-certs,target=/etc/ssl/certs \
   --mount volume=var-lib-docker,target=/var/lib/docker \
   --mount volume=var-lib-kubelet,target=/var/lib/kubelet \

--- a/templates/kubelet.service
+++ b/templates/kubelet.service
@@ -14,6 +14,9 @@ ExecStart={{coreos_kubelet_install_dir}}/kubelet-wrapper \
   --hostname-override={{ansible_default_ipv4.address}} \
   --volume-plugin-dir=/etc/kubernetes/volumeplugins \
   --register-node=true \
+{% if kubernetes_enable_cni %}
+  --network-plugin=cni \
+{% endif %}
 {% if inventory_hostname in groups['kubernetes-masters'] %}
   --kubeconfig=/etc/kubernetes/apiserver-kubeconfig.yaml \
 {% else %}


### PR DESCRIPTION
If kubernetes_enable_cni=True, start kubelet with --network-plugin=cni option to support CNI Plugins (e.g. Antrea)